### PR TITLE
0.15

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -20,6 +20,7 @@
         "Random.Window"
     ],
     "dependencies": {
-        "elm-lang/core": "1.1.0 <= v < 2.0.0"
-    }
+        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -20,6 +20,7 @@
         "Random.Window"
     ],
     "dependencies": {
+        "TheSeamau5/elm-task-extra": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.15.0 <= v < 0.16.0"

--- a/src/Random/Array.elm
+++ b/src/Random/Array.elm
@@ -6,9 +6,9 @@ module Random.Array where
 
 -}
 
-import Array (Array, fromList, empty)
-import Random (..)
-import Random.Extra (map, flatMap, constant)
+import Array        exposing (Array, fromList, empty)
+import Random       exposing (Generator, list, int)
+import Random.Extra exposing (map, flatMap, constant)
 
 {-| Generate a random array of given size given a random generator
 
@@ -29,4 +29,4 @@ a maximum length.
 -}
 rangeLengthArray : Int -> Int -> Generator a -> Generator (Array a)
 rangeLengthArray minLength maxLength generator =
-  flatMap (\len -> array len generator) (int minLength maxLength) 
+  flatMap (\len -> array len generator) (int minLength maxLength)

--- a/src/Random/Bool.elm
+++ b/src/Random/Bool.elm
@@ -1,11 +1,14 @@
 module Random.Bool where
 {-|
+
 # Generators
 @docs bool
+
 -}
 
 import Random       exposing (Generator)
 import Random.Extra exposing (frequency, constant)
+
 {-| Random Bool generator
 -}
 bool : Generator Bool

--- a/src/Random/Bool.elm
+++ b/src/Random/Bool.elm
@@ -1,5 +1,5 @@
 module Random.Bool where
-{-|
+{-| List of Bool Generators
 
 # Generators
 @docs bool

--- a/src/Random/Bool.elm
+++ b/src/Random/Bool.elm
@@ -4,19 +4,13 @@ module Random.Bool where
 @docs bool
 -}
 
-import Random exposing (Generator, generate, customGenerator, int)
-
+import Random       exposing (Generator)
+import Random.Extra exposing (frequency, constant)
 {-| Random Bool generator
 -}
 bool : Generator Bool
 bool =
-  customGenerator
-    (\seed ->
-        let (value1, seed1) = generate (int 0 1) seed
-            (value2, seed2) = generate (int 0 1) seed1
-        in
-          if (value1 + value2) == 1
-          then
-            (False, seed2)
-          else
-            (True, seed2))
+  frequency
+    [ (1, constant True)
+    , (1, constant False)
+    ] (constant True)

--- a/src/Random/Bool.elm
+++ b/src/Random/Bool.elm
@@ -1,0 +1,18 @@
+module Random.Bool where
+
+import Random exposing (Generator, generate, customGenerator, int)
+
+{-| Random Bool generator
+-}
+bool : Generator Bool
+bool =
+  customGenerator
+    (\seed ->
+        let (value1, seed1) = generate (int 0 1) seed
+            (value2, seed2) = generate (int 0 1) seed1
+        in
+          if (value1 + value2) == 1
+          then
+            (False, seed2)
+          else
+            (True, seed2))

--- a/src/Random/Bool.elm
+++ b/src/Random/Bool.elm
@@ -1,4 +1,8 @@
 module Random.Bool where
+{-|
+# Generators
+@docs bool
+-}
 
 import Random exposing (Generator, generate, customGenerator, int)
 

--- a/src/Random/Char.elm
+++ b/src/Random/Char.elm
@@ -9,9 +9,9 @@ module Random.Char where
 
 -}
 
-import Char (fromCode)
-import Random (..)
-import Random.Extra (map, merge)
+import Char exposing (fromCode)
+import Random exposing (..)
+import Random.Extra exposing (map, merge)
 
 {-| Generate a random character within a certain keyCode range
 

--- a/src/Random/Char.elm
+++ b/src/Random/Char.elm
@@ -9,8 +9,8 @@ module Random.Char where
 
 -}
 
-import Char exposing (fromCode)
-import Random exposing (..)
+import Char         exposing (fromCode)
+import Random       exposing (Generator, int)
 import Random.Extra exposing (map, merge)
 
 {-| Generate a random character within a certain keyCode range

--- a/src/Random/Color.elm
+++ b/src/Random/Color.elm
@@ -6,64 +6,64 @@ module Random.Color where
 
 -}
 
-import Color
-import Random exposing (..)
+import Color        exposing (Color)
+import Random       exposing (Generator, int, float)
 import Random.Extra exposing (map, map3, map4)
 
 {-| Generate a random color
 -}
-color : Generator Color.Color
+color : Generator Color
 color =
   map4 Color.rgba (int 0 255) (int 0 255) (int 0 255) (float 0 1)
 
 {-| Generate a random color which randomizes rgb values
 -}
-rgb : Generator Color.Color
+rgb : Generator Color
 rgb =
   map3 Color.rgb (int 0 255) (int 0 255) (int 0 255)
 
 {-| Generate a random color which randomizes rgba values
 -}
-rgba : Generator Color.Color
+rgba : Generator Color
 rgba = color
 
 {-| Generate a random color which randomizes hsl values
 -}
-hsl : Generator Color.Color
+hsl : Generator Color
 hsl =
   map3 Color.hsl (map degrees (float 0 360)) (float 0 1) (float 0 1)
 
 {-| Generate a random color which randomizes hsla values
 -}
-hsla : Generator Color.Color
+hsla : Generator Color
 hsla =
   map4 Color.hsla (map degrees (float 0 360)) (float 0 1) (float 0 1) (float 0 1)
 
 {-| Generate a random shade of grey
 -}
-greyscale : Generator Color.Color
+greyscale : Generator Color
 greyscale =
   map Color.greyscale (float 0 1)
 
 {-| Alias for greyscale
 -}
-grayscale : Generator Color.Color
+grayscale : Generator Color
 grayscale = greyscale
 
 {-| Generate a random shade of red
 -}
-red : Generator Color.Color
+red : Generator Color
 red =
   map (\red -> Color.rgb red 0 0) (int 0 255)
 
 {-| Generate a random shade of green
 -}
-green : Generator Color.Color
+green : Generator Color
 green =
   map (\green -> Color.rgb 0 green 0) (int 0 255)
 
 {-| Generate a random shade of blue
 -}
-blue : Generator Color.Color
+blue : Generator Color
 blue =
   map (\blue -> Color.rgb 0 0 blue) (int 0 255)

--- a/src/Random/Color.elm
+++ b/src/Random/Color.elm
@@ -7,8 +7,8 @@ module Random.Color where
 -}
 
 import Color
-import Random (..)
-import Random.Extra (map, map3, map4)
+import Random exposing (..)
+import Random.Extra exposing (map, map3, map4)
 
 {-| Generate a random color
 -}

--- a/src/Random/Date.elm
+++ b/src/Random/Date.elm
@@ -6,9 +6,9 @@ module Random.Date where
 
 -}
 
-import Date exposing (Day(..), Month(..), fromTime, toTime, Date)
-import Time exposing (Time)
-import Random exposing (..)
+import Date         exposing (Day(..), Month(..), fromTime, toTime, Date)
+import Time         exposing (Time)
+import Random       exposing (Generator, int, float)
 import Random.Extra exposing (map)
 
 {-| Generate a random day of the week.

--- a/src/Random/Date.elm
+++ b/src/Random/Date.elm
@@ -9,44 +9,40 @@ module Random.Date where
 import Date         exposing (Day(..), Month(..), fromTime, toTime, Date)
 import Time         exposing (Time)
 import Random       exposing (Generator, int, float)
-import Random.Extra exposing (map)
+import Random.Extra exposing (map, selectWithDefault)
 
 {-| Generate a random day of the week.
 -}
 day : Generator Day
 day =
-  let intToDay int =
-        case int of
-          0 -> Mon
-          1 -> Tue
-          2 -> Wed
-          3 -> Thu
-          4 -> Fri
-          5 -> Sat
-          _ -> Sun
-  in
-    map intToDay (int 0 6)
+  selectWithDefault Mon
+    [ Mon
+    , Tue
+    , Wed
+    , Thu
+    , Fri
+    , Sat
+    , Sun
+    ]
 
 {-| Generate a random month of the year.
 -}
 month : Generator Month
 month =
-  let intToMonth int =
-        case int of
-          0   -> Jan
-          1   -> Feb
-          2   -> Mar
-          3   -> Apr
-          4   -> May
-          5   -> Jun
-          6   -> Jul
-          7   -> Aug
-          8   -> Sep
-          9   -> Oct
-          10  -> Nov
-          _   -> Dec
-  in
-    map intToMonth (int 0 11)
+  selectWithDefault Jan
+    [ Jan
+    , Feb
+    , Mar
+    , Apr
+    , May
+    , Jun
+    , Jul
+    , Aug
+    , Sep
+    , Oct
+    , Nov
+    , Dec
+    ]
 
 {-| Generate a random year given a start year and end year (alias for `int`)
 -}

--- a/src/Random/Date.elm
+++ b/src/Random/Date.elm
@@ -6,10 +6,10 @@ module Random.Date where
 
 -}
 
-import Date (Day(..), Month(..), fromTime, toTime, Date)
-import Time (Time)
-import Random (..)
-import Random.Extra (map)
+import Date exposing (Day(..), Month(..), fromTime, toTime, Date)
+import Time exposing (Time)
+import Random exposing (..)
+import Random.Extra exposing (map)
 
 {-| Generate a random day of the week.
 -}

--- a/src/Random/Dict.elm
+++ b/src/Random/Dict.elm
@@ -6,8 +6,8 @@ module Random.Dict where
 
 -}
 
-import Dict exposing (Dict, fromList, empty)
-import Random exposing (..)
+import Dict         exposing (Dict, fromList, empty)
+import Random       exposing (Generator, list, int)
 import Random.Extra exposing (zip, map, flatMap, constant)
 
 {-| Generate a random dict with given length, key generator, and value generator

--- a/src/Random/Dict.elm
+++ b/src/Random/Dict.elm
@@ -6,9 +6,9 @@ module Random.Dict where
 
 -}
 
-import Dict (Dict, fromList, empty)
-import Random (..)
-import Random.Extra (zip, map, flatMap, constant)
+import Dict exposing (Dict, fromList, empty)
+import Random exposing (..)
+import Random.Extra exposing (zip, map, flatMap, constant)
 
 {-| Generate a random dict with given length, key generator, and value generator
 
@@ -29,4 +29,4 @@ a maximum length.
 -}
 rangeLengthDict : Int -> Int -> Generator comparable -> Generator value -> Generator (Dict comparable value)
 rangeLengthDict minLength maxLength keyGenerator valueGenerator =
-  flatMap (\len -> dict len keyGenerator valueGenerator) (int minLength maxLength) 
+  flatMap (\len -> dict len keyGenerator valueGenerator) (int minLength maxLength)

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -1,40 +1,4 @@
-module Random.Extra
-  ( constant
-  , emptyList
-  , flattenList
-  , rangeLengthList
-  , bool
-  , andMap
-  , select
-  , selectWithDefault
-  , map
-  , map2
-  , map3
-  , map4
-  , map5
-  , map6
-  , flatMap
-  , flatMap2
-  , flatMap3
-  , flatMap4
-  , flatMap5
-  , flatMap6
-  , zip
-  , zip3
-  , zip4
-  , zip5
-  , zip6
-  , andThen
-  , merge
-  , quickGenerate
-  , cappedGenerateUntil
-  , generateIterativelyUntil
-  , generateIterativelySuchThat
-  , generateUntil
-  , generateSuchThat
-  , generateWithDefault
-  , maybeGenerateSuchThat
-  ) where
+module Random.Extra where
 {-| Module providing extra functionality to the core Random module.
 
 # Constant Generators
@@ -174,9 +138,6 @@ andMap funcGenerator generator =
             (a, seed2) = generate generator seed1
         in
           ((f a), seed2))
-
-
-
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -1,6 +1,7 @@
 module Random.Extra
   ( constant
   , emptyList
+  , flattenList
   , rangeLengthList
   , bool
   , anyInt
@@ -58,7 +59,7 @@ module Random.Extra
 {-| Module providing extra functionality to the core Random module.
 
 # Constant Generators
-@docs constant, emptyList
+@docs constant, emptyList, flattenList
 
 # Boolean Generator
 @docs bool
@@ -120,6 +121,19 @@ get index list =
 emptyList : Generator (List a)
 emptyList =
   constant []
+
+{-| Turn a list of generators into a generator of lists.
+-}
+flattenList : List (Generator a) -> Generator (List a)
+flattenList generators = case generators of
+  [] -> emptyList
+  g :: gs ->
+    customGenerator <|
+      \seed ->
+        let (first, seed1)  = generate g seed
+            (rest , seed2)  = generate (flattenList gs) seed1
+        in
+            (first :: rest, seed2)
 
 {-| Generate a random list of random length given a minimum length and
 a maximum length.

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -53,7 +53,7 @@ module Random.Extra
   , generateUntil
   , generateSuchThat
   , maybeGenerateSuchThat
-  )where
+  ) where
 {-| Module providing extra functionality to the core Random module.
 
 # Constant Generators
@@ -100,7 +100,7 @@ module Random.Extra
 
 -}
 
-import Random (..)
+import Random exposing (..)
 import List
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -8,7 +8,7 @@ module Random.Extra where
 @docs flattenList
 
 # Select
-@docs select, selectWithDefault
+@docs select, selectWithDefault, frequency
 
 # Maps
 @docs map, map2, map3, map4, map5, map6, mapConstraint
@@ -30,10 +30,41 @@ module Random.Extra where
 
 -}
 
-import Random       exposing (Generator, Seed, generate, customGenerator, list, int)
+import Random       exposing (Generator, Seed, generate, customGenerator, list, int, float)
 import Random.Bool  exposing (bool)
 import Utils        exposing (get)
 import List
+
+frequency : List (Float, Generator a) -> Generator a -> Generator a
+frequency pairs defaultGenerator =
+  let
+      frequencies : List Float
+      frequencies = List.map (abs << fst) pairs
+
+      total : Float
+      total = List.sum frequencies
+  in
+      if total == 0
+      then
+        defaultGenerator
+      else
+        customGenerator <|
+          \seed ->
+            let
+                (randIndex, seed1) = generate (float 0 total) seed
+
+                index = floor randIndex
+
+                maybePair = get index pairs
+
+                generator = case maybePair of
+                  Nothing -> defaultGenerator
+                  Just (_ , gen) -> gen
+
+            in
+                generate generator seed
+
+
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -30,10 +30,10 @@ module Random.Extra where
 
 -}
 
-import Random exposing (..)
-import Random.Bool exposing (bool)
+import Random       exposing (Generator, Seed, generate, customGenerator, list, int)
+import Random.Bool  exposing (bool)
+import Utils        exposing (get)
 import List
-import Utils exposing (get)
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -37,13 +37,6 @@ import Utils exposing (get)
 
 
 
-
-{-| Generator that always returns the empty list.
--}
-emptyList : Generator (List a)
-emptyList =
-  constant []
-
 {-| Turn a list of generators into a generator of lists.
 -}
 flattenList : List (Generator a) -> Generator (List a)
@@ -57,12 +50,6 @@ flattenList generators = case generators of
         in
             (first :: rest, seed2)
 
-{-| Generate a random list of random length given a minimum length and
-a maximum length.
--}
-rangeLengthList : Int -> Int -> Generator a -> Generator (List a)
-rangeLengthList minLength maxLength generator =
-  flatMap (\len -> list len generator) (int minLength maxLength)
 
 {-| Generator that randomly selects an element from a list.
 -}

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -317,16 +317,10 @@ map6 f generatorA generatorB generatorC generatorD generatorE generatorF =
 
 merge : Generator a -> Generator a -> Generator a
 merge generator1 generator2 =
-  customGenerator
-    (\seed ->
-        let value = quickGenerate bool seed
-        in
-          if value == True
-          then
-            generate generator1 seed
-          else
-            generate generator2 seed)
-
+  frequency
+    [ (1, generator1)
+    , (1, generator2)
+    ] generator1
 
 generateSuchThat : (a -> Bool) -> Generator a -> Seed -> (a, Seed)
 generateSuchThat predicate generator seed =

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -41,7 +41,7 @@ import Utils exposing (get)
 -}
 flattenList : List (Generator a) -> Generator (List a)
 flattenList generators = case generators of
-  [] -> emptyList
+  [] -> constant []
   g :: gs ->
     customGenerator <|
       \seed ->

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -2,10 +2,10 @@ module Random.Extra where
 {-| Module providing extra functionality to the core Random module.
 
 # Constant Generators
-@docs constant, emptyList, flattenList
+@docs constant
 
-# List Generators
-@docs rangeLengthList
+# Generator Transformers
+@docs flattenList
 
 # Select
 @docs select, selectWithDefault

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -33,16 +33,9 @@ module Random.Extra where
 import Random exposing (..)
 import Random.Bool exposing (bool)
 import List
+import Utils exposing (get)
 
 
-get : Int -> List a -> Maybe a
-get index list =
-  if index < 0
-  then Nothing
-  else
-    case List.drop index list of
-      [] -> Nothing
-      x :: xs -> Just x
 
 
 {-| Generator that always returns the empty list.

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -65,7 +65,25 @@ frequency pairs defaultGenerator =
                 generate generator seed
 
 
+keepIf : (a -> Bool) -> Generator a -> Generator a
+keepIf predicate generator =
+  let
+      gen seed =
+        let
+            (value, seed1) = generate generator seed
+        in
+            if predicate value
+            then
+              (value, seed1)
+            else
+              gen seed1
+  in
+      customGenerator gen
 
+
+dropIf : (a -> Bool) -> Generator a -> Generator a
+dropIf predicate =
+  keepIf (\a -> not (predicate a))
 
 
 {-| Turn a list of generators into a generator of lists.

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -8,7 +8,7 @@ module Random.Extra where
 @docs flattenList
 
 # Select
-@docs select, selectWithDefault, frequency
+@docs select, selectWithDefault, frequency, merge
 
 # Maps
 @docs map, map2, map3, map4, map5, map6, mapConstraint
@@ -24,9 +24,6 @@ module Random.Extra where
 
 # Filtering Generators
 @docs keepIf, dropIf
-
-# Merging Generators
-@docs merge
 
 # Generate Functions
 @docs quickGenerate, cappedGenerateUntil, generateIterativelyUntil, generateIterativelySuchThat, generateUntil, generateSuchThat

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -34,7 +34,6 @@ module Random.Extra where
 -}
 
 import Random       exposing (Generator, Seed, generate, customGenerator, list, int, float)
-import Random.Bool  exposing (bool)
 import Utils        exposing (get)
 import List
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -22,6 +22,9 @@ module Random.Extra where
 # Chaining Generators
 @docs andMap, andThen
 
+# Filtering Generators
+@docs keepIf, dropIf
+
 # Merging Generators
 @docs merge
 
@@ -64,7 +67,10 @@ frequency pairs defaultGenerator =
             in
                 generate generator seed
 
-
+{-| Convert a generator into a generator that only generates values
+that satisfy a given predicate.
+Note that if the predicate is unsatisfiable, the generator will not terminate.
+-}
 keepIf : (a -> Bool) -> Generator a -> Generator a
 keepIf predicate generator =
   let
@@ -81,6 +87,9 @@ keepIf predicate generator =
       customGenerator gen
 
 
+{-| Convert a generator into a generator that only generates values
+that do not satisfy a given predicate.
+-}
 dropIf : (a -> Bool) -> Generator a -> Generator a
 dropIf predicate =
   keepIf (\a -> not (predicate a))

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -52,6 +52,7 @@ module Random.Extra
   , generateIterativelySuchThat
   , generateUntil
   , generateSuchThat
+  , generateWithDefault
   , maybeGenerateSuchThat
   ) where
 {-| Module providing extra functionality to the core Random module.

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -26,7 +26,7 @@ module Random.Extra where
 @docs keepIf, dropIf
 
 # Generate Functions
-@docs quickGenerate, cappedGenerateUntil, generateIterativelyUntil, generateIterativelySuchThat, generateUntil, generateSuchThat
+@docs generateN, quickGenerate, cappedGenerateUntil, generateIterativelyUntil, generateIterativelySuchThat, generateUntil, generateSuchThat
 
 -}
 
@@ -322,6 +322,19 @@ merge generator1 generator2 =
     [ (1, generator1)
     , (1, generator2)
     ] generator1
+
+
+{-| Generate n values from a generator.
+-}
+generateN : Int -> Generator a -> Seed -> List a
+generateN n generator seed =
+  if n <= 0
+  then
+    []
+  else
+    let (value, nextSeed) = generate generator seed
+    in
+        value :: generateN (n - 1) generator nextSeed
 
 
 {-| Generate a value from a generator that satisfies a given predicate

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -4,10 +4,6 @@ module Random.Extra where
 # Constant Generators
 @docs constant, emptyList, flattenList
 
-# Boolean Generator
-@docs bool
-
-
 # List Generators
 @docs rangeLengthList
 
@@ -35,6 +31,7 @@ module Random.Extra where
 -}
 
 import Random exposing (..)
+import Random.Bool exposing (bool)
 import List
 
 
@@ -110,23 +107,6 @@ constant value =
         let (_, seed1) = generate (int 0 1) seed
         in
           (value, seed1))
-
-
-
-{-| Random Bool generator
--}
-bool : Generator Bool
-bool =
-  customGenerator
-    (\seed ->
-        let (value1, seed1) = generate (int 0 1) seed
-            (value2, seed2) = generate (int 0 1) seed1
-        in
-          if (value1 + value2) == 1
-          then
-            (False, seed2)
-          else
-            (True, seed2))
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -153,7 +153,9 @@ constant value =
           (value, seed1))
 
 
-
+{-| Apply a generator of functions to a generator of values.
+Useful for chaining generators.
+-}
 andMap : Generator (a -> b) -> Generator a -> Generator b
 andMap funcGenerator generator =
   customGenerator <|

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -4,11 +4,6 @@ module Random.Extra
   , flattenList
   , rangeLengthList
   , bool
-  , anyInt
-  , positiveInt
-  , negativeInt
-  , intGreaterThan
-  , intLessThan
   , anyFloat
   , positiveFloat
   , negativeFloat
@@ -64,8 +59,6 @@ module Random.Extra
 # Boolean Generator
 @docs bool
 
-# Integer Generators
-@docs anyInt, positiveInt, negativeInt, intGreaterThan, intLessThan
 
 # Float Generators
 @docs anyFloat, positiveFloat, negativeFloat, floatGreaterThan, floatLessThan, probability, negativeProbability, absoluteProbability
@@ -279,30 +272,6 @@ infixr 9 <<<
         in
           (f >> g, seed2))
 
-{-| Generator that generates any int that can be generate by the random generator algorithm.
--}
-anyInt : Generator Int
-anyInt = int minInt maxInt
-
-{-| Generator that generates a positive int
--}
-positiveInt : Generator Int
-positiveInt = int 1 maxInt
-
-{-| Generator that generates a negative int
--}
-negativeInt : Generator Int
-negativeInt = int minInt -1
-
-{-| Generator that generates an int greater than a given int
--}
-intGreaterThan : Int -> Generator Int
-intGreaterThan value = int (value + 1) maxInt
-
-{-| Generator that generates an int less than a given int
--}
-intLessThan : Int -> Generator Int
-intLessThan value = int minInt (value - 1)
 
 {-| Generator that generates any float
 -}

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -4,14 +4,6 @@ module Random.Extra
   , flattenList
   , rangeLengthList
   , bool
-  , anyFloat
-  , positiveFloat
-  , negativeFloat
-  , floatGreaterThan
-  , floatLessThan
-  , probability
-  , negativeProbability
-  , absoluteProbability
   , func
   , func2
   , func3
@@ -59,9 +51,6 @@ module Random.Extra
 # Boolean Generator
 @docs bool
 
-
-# Float Generators
-@docs anyFloat, positiveFloat, negativeFloat, floatGreaterThan, floatLessThan, probability, negativeProbability, absoluteProbability
 
 # List Generators
 @docs rangeLengthList
@@ -272,68 +261,6 @@ infixr 9 <<<
         in
           (f >> g, seed2))
 
-
-{-| Generator that generates any float
--}
-anyFloat : Generator Float
-anyFloat = float (toFloat minInt) (toFloat maxInt)
-
-{-| Generator that generates any positive float
--}
-positiveFloat : Generator Float
-positiveFloat = float 0 (toFloat maxInt)
-
-{-| Generator that generates any negative float
--}
-negativeFloat : Generator Float
-negativeFloat = float (toFloat minInt) 0
-
-{-| Generator that generates a float greater than a given float
--}
-floatGreaterThan : Float -> Generator Float
-floatGreaterThan value = float value (toFloat maxInt)
-
-{-| Generator that generates a float less than a given float
--}
-floatLessThan : Float -> Generator Float
-floatLessThan value = float (toFloat minInt) value
-
-{-| Generator that generates a float between 0 and 1
--}
-probability : Generator Float
-probability = float 0 1
-
-{-| Generator that generates a float between -1 and 0
--}
-negativeProbability : Generator Float
-negativeProbability = float -1 0
-
-{-| Generator that generates a float between - 1 and 1
--}
-absoluteProbability : Generator Float
-absoluteProbability = float -1 1
-
-{-}
-normal : Float -> Float -> Float -> Generator Float
-normal start end standardDeviation =
-  let normalDistribution mean stdDev x =
-        if stdDev == 0 then x
-        else
-          let scale = 1 / (stdDev * sqrt (2 * pi))
-              exponent = ((x - mean) * (x - mean)) / (2 * stdDev * stdDev)
-          in
-            scale * (e ^ -exponent)
-
-  in
-    map (normalDistribution ((end - start) / 2) standardDeviation) (float start end)
-
-standardNormal : Generator Float
-standardNormal = normal (toFloat minInt + 1) (toFloat maxInt) 1
-
-gaussian : Float -> Float -> Float -> Generator Float
-gaussian = normal
-
--}
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -38,6 +38,13 @@ import Random.Bool  exposing (bool)
 import Utils        exposing (get)
 import List
 
+{-| Create a generator that chooses a generator from a tuple of generators
+based on the provided likelihood. The likelihood of a given generator being
+chosen is its likelihood divided by the sum of all likelihood. A default
+generator must be provided in the case that the list is empty or that the
+sum of the likelihoods is 0. Note that the absolute values of the likelihoods
+is always taken.
+-}
 frequency : List (Float, Generator a) -> Generator a -> Generator a
 frequency pairs defaultGenerator =
   let
@@ -366,7 +373,7 @@ generateIterativelySuchThat maxLength predicate constructor seed =
         then
           []
         else
-          (generateUntil notPredicate (constructor index) seed) `List.append`
+          (generateUntil notPredicate (constructor index) seed) ++
           (iterate (index + 1))
 
   in

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -19,6 +19,9 @@ module Random.Extra where
 # Zips
 @docs zip, zip3, zip4, zip5, zip6
 
+# Reducers
+@docs reduce, fold
+
 # Chaining Generators
 @docs andMap, andThen
 
@@ -154,6 +157,26 @@ andMap funcGenerator generator =
             (a, seed2) = generate generator seed1
         in
           ((f a), seed2))
+
+
+{-| Reduce a generator using a reducer and an initial value.
+-}
+reduce : (a -> b -> b) -> b -> Generator a -> Generator b
+reduce reducer initial generator =
+  let
+      gen seed =
+        let (value, nextSeed) = generate generator seed
+            nextValue = reducer value initial
+        in
+            (nextValue, nextSeed)
+  in
+      customGenerator gen
+
+
+{-| Alias for reduce.
+-}
+fold : (a -> b -> b) -> b -> Generator a -> Generator b
+fold = reduce
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -33,6 +33,7 @@ module Random.Extra where
 import Random       exposing (Generator, Seed, generate, customGenerator, list, int, float, initialSeed)
 import Utils        exposing (get)
 import List
+import Maybe
 
 {-| Create a generator that chooses a generator from a tuple of generators
 based on the provided likelihood. The likelihood of a given generator being
@@ -128,15 +129,7 @@ select list =
 -}
 selectWithDefault : a -> List a -> Generator a
 selectWithDefault defaultValue list =
-  customGenerator <|
-    (\seed ->
-        let (index, nextSeed) = generate (int 0 (List.length list - 1)) seed
-        in
-          case get index list of
-            Nothing     -> (defaultValue, nextSeed)
-            Just value  -> (value, nextSeed))
-
-
+  map (Maybe.withDefault defaultValue) (select list)
 
 
 {-| Create a generator that always returns the same value.

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -4,15 +4,7 @@ module Random.Extra
   , flattenList
   , rangeLengthList
   , bool
-  , func
-  , func2
-  , func3
-  , func4
-  , func5
-  , func6
-  , apply
-  , (<<<)
-  , (>>>)
+  , andMap
   , select
   , selectWithDefault
   , map
@@ -55,12 +47,6 @@ module Random.Extra
 # List Generators
 @docs rangeLengthList
 
-# Function Generators
-@docs func, func2, func3, func4, func5, func6
-
-# Operations on Function Generators
-@docs apply, (<<<), (>>>)
-
 # Select
 @docs select, selectWithDefault
 
@@ -74,7 +60,7 @@ module Random.Extra
 @docs zip, zip3, zip4, zip5, zip6
 
 # Chaining Generators
-@docs andThen
+@docs andMap, andThen
 
 # Merging Generators
 @docs merge
@@ -180,8 +166,8 @@ bool =
 
 
 
-apply : Generator (a -> b) -> Generator a -> Generator b
-apply funcGenerator generator =
+andMap : Generator (a -> b) -> Generator a -> Generator b
+andMap funcGenerator generator =
   customGenerator <|
     (\seed ->
         let (f, seed1) = generate funcGenerator seed
@@ -189,77 +175,6 @@ apply funcGenerator generator =
         in
           ((f a), seed2))
 
-
-{-| Generates a random function of one argument given a generator for the output.
--}
-func : Generator b -> Generator (a -> b)
-func generatorB =
-  customGenerator <|
-    (\seed ->
-        let (valueB, seed1) = generate generatorB seed
-        in
-          ((\a -> valueB), seed1))
-
-
-{-| Generates a random function of two arguments given a generator for the output.
--}
-func2 : Generator c -> Generator (a -> b -> c)
-func2 generatorC =
-  func (func generatorC)
-
-
-{-| Generates a random function of three arguments given a generator for the output.
--}
-func3 : Generator d -> Generator (a -> b -> c -> d)
-func3 generatorD =
-  func (func2 generatorD)
-
-
-{-| Generates a random function of four arguments given a generator for the output.
--}
-func4 : Generator e -> Generator (a -> b -> c -> d -> e)
-func4 generatorE =
-  func (func3 generatorE)
-
-
-{-| Generates a random function of five arguments given a generator for the output.
--}
-func5 : Generator f -> Generator (a -> b -> c -> d -> e -> f)
-func5 generatorF =
-  func (func4 generatorF)
-
-
-{-| Generates a random function of six arguments given a generator for the output.
--}
-func6 : Generator g -> Generator (a -> b -> c -> d -> e -> f -> g)
-func6 generatorG =
-  func (func5 generatorG)
-
-
-infixl 9 >>>
-{-| Compose two function generators. Analogous to `>>`
--}
-(>>>) : Generator (a -> b) -> Generator (b -> c) -> Generator (a -> c)
-(>>>) generatorAB generatorBC =
-  customGenerator <|
-    (\seed ->
-        let (f, seed1) = generate generatorAB seed
-            (g, seed2) = generate generatorBC seed1
-        in
-          (f >> g, seed2))
-
-
-infixr 9 <<<
-{-| Compose two function generators. Analogous to `<<`
--}
-(<<<) : Generator (b -> c) -> Generator (a -> b) -> Generator (a -> c)
-(<<<) generatorBC generatorAB =
-  customGenerator <|
-    (\seed ->
-        let (f, seed1) = generate generatorAB seed
-            (g, seed2) = generate generatorBC seed1
-        in
-          (f >> g, seed2))
 
 
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -49,7 +49,7 @@ frequency pairs defaultGenerator =
       frequencies = List.map (abs << fst) pairs
 
       total : Float
-      total = List.sum frequencies
+      total = List.sum frequencies * (toFloat <| List.length frequencies)
   in
       if total == 0
       then

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -1,5 +1,5 @@
 module Random.Float where
-{-|
+{-| List of Float Generators
 
 # Generators
 @docs anyFloat, positiveFloat, negativeFloat, floatGreaterThan, floatLessThan, probability, negativeProbability, unitRange

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -9,7 +9,8 @@ module Random.Float where
 
 -}
 
-import Random exposing (Generator, float, maxInt, minInt)
+import Random       exposing (Generator, float, maxInt, minInt, customGenerator, generate)
+import Random.Extra exposing (map)
 
 
 {-| Generator that generates any float

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -1,0 +1,66 @@
+module Random.Float where
+
+import Random exposing (Generator, float, maxInt, minInt)
+
+
+{-| Generator that generates any float
+-}
+anyFloat : Generator Float
+anyFloat = float (toFloat minInt) (toFloat maxInt)
+
+{-| Generator that generates any positive float
+-}
+positiveFloat : Generator Float
+positiveFloat = float 0 (toFloat maxInt)
+
+{-| Generator that generates any negative float
+-}
+negativeFloat : Generator Float
+negativeFloat = float (toFloat minInt) 0
+
+{-| Generator that generates a float greater than a given float
+-}
+floatGreaterThan : Float -> Generator Float
+floatGreaterThan value = float value (toFloat maxInt)
+
+{-| Generator that generates a float less than a given float
+-}
+floatLessThan : Float -> Generator Float
+floatLessThan value = float (toFloat minInt) value
+
+{-| Generator that generates a float between 0 and 1
+-}
+probability : Generator Float
+probability = float 0 1
+
+{-| Generator that generates a float between -1 and 0
+-}
+negativeProbability : Generator Float
+negativeProbability = float -1 0
+
+{-| Generator that generates a float between - 1 and 1
+-}
+absoluteProbability : Generator Float
+absoluteProbability = float -1 1
+
+{-}
+normal : Float -> Float -> Float -> Generator Float
+normal start end standardDeviation =
+  let normalDistribution mean stdDev x =
+        if stdDev == 0 then x
+        else
+          let scale = 1 / (stdDev * sqrt (2 * pi))
+              exponent = ((x - mean) * (x - mean)) / (2 * stdDev * stdDev)
+          in
+            scale * (e ^ -exponent)
+
+  in
+    map (normalDistribution ((end - start) / 2) standardDeviation) (float start end)
+
+standardNormal : Generator Float
+standardNormal = normal (toFloat minInt + 1) (toFloat maxInt) 1
+
+gaussian : Float -> Float -> Float -> Generator Float
+gaussian = normal
+
+-}

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -1,4 +1,13 @@
 module Random.Float where
+{-|
+
+# Generators
+@docs anyFloat, positiveFloat, negativeFloat, floatGreaterThan, floatLessThan, probability, negativeProbability, unitRange
+
+# Gaussian Generators
+@docs normal, standardNormal, gaussian
+
+-}
 
 import Random exposing (Generator, float, maxInt, minInt)
 
@@ -40,10 +49,13 @@ negativeProbability = float -1 0
 
 {-| Generator that generates a float between - 1 and 1
 -}
-absoluteProbability : Generator Float
-absoluteProbability = float -1 1
+unitRange : Generator Float
+unitRange = float -1 1
 
-{-}
+
+{-| Create a generator of floats that is normally distributed with
+given minimum, maximum, and standard deviation.
+-}
 normal : Float -> Float -> Float -> Generator Float
 normal start end standardDeviation =
   let normalDistribution mean stdDev x =
@@ -57,10 +69,13 @@ normal start end standardDeviation =
   in
     map (normalDistribution ((end - start) / 2) standardDeviation) (float start end)
 
+{-| Generator that follows a standard normal distribution (as opposed to
+a uniform distribution)
+-}
 standardNormal : Generator Float
 standardNormal = normal (toFloat minInt + 1) (toFloat maxInt) 1
 
+{-| Alias for `normal`.
+-}
 gaussian : Float -> Float -> Float -> Generator Float
 gaussian = normal
-
--}

--- a/src/Random/Function.elm
+++ b/src/Random/Function.elm
@@ -1,4 +1,13 @@
 module Random.Function where
+{-|
+
+# Generators
+@docs func, func2, func3, func4, func5, func6
+
+# Infix operators
+@docs (<<<), (>>>)
+
+-}
 
 import Random exposing (Generator, generate, customGenerator)
 

--- a/src/Random/Function.elm
+++ b/src/Random/Function.elm
@@ -1,0 +1,74 @@
+module Random.Function where
+
+import Random exposing (Generator, generate, customGenerator)
+
+{-| Generates a random function of one argument given a generator for the output.
+-}
+func : Generator b -> Generator (a -> b)
+func generatorB =
+  customGenerator <|
+    (\seed ->
+        let (valueB, seed1) = generate generatorB seed
+        in
+          ((\a -> valueB), seed1))
+
+
+{-| Generates a random function of two arguments given a generator for the output.
+-}
+func2 : Generator c -> Generator (a -> b -> c)
+func2 generatorC =
+  func (func generatorC)
+
+
+{-| Generates a random function of three arguments given a generator for the output.
+-}
+func3 : Generator d -> Generator (a -> b -> c -> d)
+func3 generatorD =
+  func (func2 generatorD)
+
+
+{-| Generates a random function of four arguments given a generator for the output.
+-}
+func4 : Generator e -> Generator (a -> b -> c -> d -> e)
+func4 generatorE =
+  func (func3 generatorE)
+
+
+{-| Generates a random function of five arguments given a generator for the output.
+-}
+func5 : Generator f -> Generator (a -> b -> c -> d -> e -> f)
+func5 generatorF =
+  func (func4 generatorF)
+
+
+{-| Generates a random function of six arguments given a generator for the output.
+-}
+func6 : Generator g -> Generator (a -> b -> c -> d -> e -> f -> g)
+func6 generatorG =
+  func (func5 generatorG)
+
+
+infixl 9 >>>
+{-| Compose two function generators. Analogous to `>>`
+-}
+(>>>) : Generator (a -> b) -> Generator (b -> c) -> Generator (a -> c)
+(>>>) generatorAB generatorBC =
+  customGenerator <|
+    (\seed ->
+        let (f, seed1) = generate generatorAB seed
+            (g, seed2) = generate generatorBC seed1
+        in
+          (f >> g, seed2))
+
+
+infixr 9 <<<
+{-| Compose two function generators. Analogous to `<<`
+-}
+(<<<) : Generator (b -> c) -> Generator (a -> b) -> Generator (a -> c)
+(<<<) generatorBC generatorAB =
+  customGenerator <|
+    (\seed ->
+        let (f, seed1) = generate generatorAB seed
+            (g, seed2) = generate generatorBC seed1
+        in
+          (f >> g, seed2))

--- a/src/Random/Function.elm
+++ b/src/Random/Function.elm
@@ -1,5 +1,5 @@
 module Random.Function where
-{-|
+{-| List of Function Generators
 
 # Generators
 @docs func, func2, func3, func4, func5, func6

--- a/src/Random/Int.elm
+++ b/src/Random/Int.elm
@@ -1,0 +1,28 @@
+module Random.Int where
+
+import Random       exposing (Generator, int, minInt, maxInt)
+
+{-| Generator that generates any int that can be generate by the random generator algorithm.
+-}
+anyInt : Generator Int
+anyInt = int minInt maxInt
+
+{-| Generator that generates a positive int
+-}
+positiveInt : Generator Int
+positiveInt = int 1 maxInt
+
+{-| Generator that generates a negative int
+-}
+negativeInt : Generator Int
+negativeInt = int minInt -1
+
+{-| Generator that generates an int greater than a given int
+-}
+intGreaterThan : Int -> Generator Int
+intGreaterThan value = int (value + 1) maxInt
+
+{-| Generator that generates an int less than a given int
+-}
+intLessThan : Int -> Generator Int
+intLessThan value = int minInt (value - 1)

--- a/src/Random/Int.elm
+++ b/src/Random/Int.elm
@@ -1,8 +1,14 @@
 module Random.Int where
+{-|
 
-import Random       exposing (Generator, int, minInt, maxInt)
+# Generators
+@docs anyInt, positiveInt, negativeInt, intGreaterThan, intLessThan
+-}
 
-{-| Generator that generates any int that can be generate by the random generator algorithm.
+import Random exposing (Generator, int, minInt, maxInt)
+
+{-| Generator that generates any int that can be generate by the
+random generator algorithm.
 -}
 anyInt : Generator Int
 anyInt = int minInt maxInt

--- a/src/Random/Int.elm
+++ b/src/Random/Int.elm
@@ -1,5 +1,5 @@
 module Random.Int where
-{-|
+{-| List of Int Generators
 
 # Generators
 @docs anyInt, positiveInt, negativeInt, intGreaterThan, intLessThan

--- a/src/Random/Keyboard.elm
+++ b/src/Random/Keyboard.elm
@@ -16,15 +16,13 @@ import Random.Extra exposing (map)
 -}
 arrows : Generator { x : Int, y : Int }
 arrows =
-  let intToArrows int =
-        case int of
-          0 -> { x = 0, y = 0}
-          1 -> { x = 0, y = 1}
-          2 -> { x = 1, y = 0}
-          _ -> { x = 1, y = 1}
-  in
-    map intToArrows (int 0 3)
-
+  selectWithDefault { x = 0, y = 0 }
+    [ { x = 0, y = 0 }
+    , { x = 0, y = 1 }
+    , { x = 1, y = 0 }
+    , { x = 1, y = 1 }
+    ]
+    
 {-| Generate a random Keyboard input.
 -}
 keyCode : Generator KeyCode

--- a/src/Random/Keyboard.elm
+++ b/src/Random/Keyboard.elm
@@ -9,7 +9,7 @@ module Random.Keyboard where
 import List
 import Keyboard     exposing (KeyCode)
 import Random       exposing (Generator, int)
-import Random.Extra exposing (map)
+import Random.Extra exposing (map, selectWithDefault)
 
 
 {-| Generate random Keyboard arrows input
@@ -22,7 +22,7 @@ arrows =
     , { x = 1, y = 0 }
     , { x = 1, y = 1 }
     ]
-    
+
 {-| Generate a random Keyboard input.
 -}
 keyCode : Generator KeyCode

--- a/src/Random/Keyboard.elm
+++ b/src/Random/Keyboard.elm
@@ -6,9 +6,9 @@ module Random.Keyboard where
 
 -}
 
-import Keyboard exposing (KeyCode)
 import List
-import Random exposing (..)
+import Keyboard     exposing (KeyCode)
+import Random       exposing (Generator, int)
 import Random.Extra exposing (map)
 
 

--- a/src/Random/Keyboard.elm
+++ b/src/Random/Keyboard.elm
@@ -6,10 +6,10 @@ module Random.Keyboard where
 
 -}
 
-import Keyboard (KeyCode)
+import Keyboard exposing (KeyCode)
 import List
-import Random (..)
-import Random.Extra (map)
+import Random exposing (..)
+import Random.Extra exposing (map)
 
 
 {-| Generate random Keyboard arrows input

--- a/src/Random/List.elm
+++ b/src/Random/List.elm
@@ -1,4 +1,10 @@
 module Random.List where
+{-|
+
+# Generators
+@docs emptyList, rangeLengthList
+
+-}
 
 import Random       exposing (Generator, int, list)
 import Random.Extra exposing (flatMap, constant)

--- a/src/Random/List.elm
+++ b/src/Random/List.elm
@@ -1,7 +1,7 @@
 module Random.List where
 
-import Random       exposing (Generator, int, constant)
-import Random.Extra exposing (flatMap)
+import Random       exposing (Generator, int, list)
+import Random.Extra exposing (flatMap, constant)
 
 {-| Generator that always returns the empty list.
 -}

--- a/src/Random/List.elm
+++ b/src/Random/List.elm
@@ -1,5 +1,5 @@
 module Random.List where
-{-|
+{-| List of List Generators
 
 # Generators
 @docs emptyList, rangeLengthList

--- a/src/Random/List.elm
+++ b/src/Random/List.elm
@@ -1,0 +1,18 @@
+module Random.List where
+
+import Random       exposing (Generator, int, constant)
+import Random.Extra exposing (flatMap)
+
+{-| Generator that always returns the empty list.
+-}
+emptyList : Generator (List a)
+emptyList =
+  constant []
+
+
+{-| Generate a random list of random length given a minimum length and
+a maximum length.
+-}
+rangeLengthList : Int -> Int -> Generator a -> Generator (List a)
+rangeLengthList minLength maxLength generator =
+  flatMap (\len -> list len generator) (int minLength maxLength)

--- a/src/Random/Mailbox.elm
+++ b/src/Random/Mailbox.elm
@@ -1,0 +1,15 @@
+module Random.Mailbox where
+
+import Signal       exposing (Mailbox, Address)
+import Random       exposing (Generator)
+import Random.Extra exposing (map)
+
+
+mailbox : Generator a -> Generator (Mailbox a)
+mailbox generator =
+  map Signal.mailbox generator
+
+
+address : Generator a -> Generator (Address a)
+address generator =
+  map .address (mailbox generator)

--- a/src/Random/Mailbox.elm
+++ b/src/Random/Mailbox.elm
@@ -1,15 +1,24 @@
 module Random.Mailbox where
+{-|
+
+# Generators
+@docs mailbox, address
+-}
 
 import Signal       exposing (Mailbox, Address)
 import Random       exposing (Generator)
 import Random.Extra exposing (map)
 
 
+{-| Generates a random mailbox
+-}
 mailbox : Generator a -> Generator (Mailbox a)
 mailbox generator =
   map Signal.mailbox generator
 
 
+{-| Generates a random mailbox address
+-}
 address : Generator a -> Generator (Address a)
 address generator =
   map .address (mailbox generator)

--- a/src/Random/Mailbox.elm
+++ b/src/Random/Mailbox.elm
@@ -1,5 +1,5 @@
 module Random.Mailbox where
-{-|
+{-| List of Mailbox Generators
 
 # Generators
 @docs mailbox, address

--- a/src/Random/Maybe.elm
+++ b/src/Random/Maybe.elm
@@ -2,7 +2,8 @@ module Random.Maybe where
 {-| List of Maybe Generators
 
 # Generators
-@docs maybe
+@docs maybe, withDefault, withDefaultGenerator
+
 -}
 
 import Random       exposing (Generator)

--- a/src/Random/Maybe.elm
+++ b/src/Random/Maybe.elm
@@ -1,0 +1,18 @@
+module Random.Maybe where
+{-| List of Maybe Generators
+
+# Generators
+@docs maybe
+-}
+
+import Random       exposing (Generator)
+import Random.Extra exposing (constant, map, frequency)
+
+{-| Generate a Maybe from a generator. Will generate Nothings 50% of the time.
+-}
+maybe : Generator a -> Generator (Maybe a)
+maybe generator =
+  frequency
+    [ (1, constant Nothing)
+    , (1, map Just generator)
+    ] (constant Nothing)

--- a/src/Random/Maybe.elm
+++ b/src/Random/Maybe.elm
@@ -6,7 +6,8 @@ module Random.Maybe where
 -}
 
 import Random       exposing (Generator)
-import Random.Extra exposing (constant, map, frequency)
+import Random.Extra exposing (constant, map, frequency, flatMap)
+import Maybe
 
 {-| Generate a Maybe from a generator. Will generate Nothings 50% of the time.
 -}
@@ -16,3 +17,15 @@ maybe generator =
     [ (1, constant Nothing)
     , (1, map Just generator)
     ] (constant Nothing)
+
+{-| Generate values from a maybe generator or a default value.
+-}
+withDefault : a -> Generator (Maybe a) -> Generator a
+withDefault value generator =
+  map (Maybe.withDefault value) generator
+
+{-| Generate values from a maybe generator or a default generator.
+-}
+withDefaultGenerator : Generator a -> Generator (Maybe a) -> Generator a
+withDefaultGenerator default generator =
+  flatMap (flip withDefault generator) default

--- a/src/Random/Mouse.elm
+++ b/src/Random/Mouse.elm
@@ -6,8 +6,8 @@ module Random.Mouse where
 
 -}
 
-import Random (..)
-import Random.Extra (bool, zip)
+import Random exposing (..)
+import Random.Extra exposing (bool, zip)
 
 {-| Generate a random mouse position given a screen width and a screen height
 -}

--- a/src/Random/Mouse.elm
+++ b/src/Random/Mouse.elm
@@ -6,7 +6,7 @@ module Random.Mouse where
 
 -}
 
-import Random exposing (..)
+import Random       exposing (Generator, int)
 import Random.Extra exposing (bool, zip)
 
 {-| Generate a random mouse position given a screen width and a screen height

--- a/src/Random/Mouse.elm
+++ b/src/Random/Mouse.elm
@@ -7,7 +7,8 @@ module Random.Mouse where
 -}
 
 import Random       exposing (Generator, int)
-import Random.Extra exposing (bool, zip)
+import Random.Extra exposing (zip)
+import Random.Bool  exposing (bool)
 
 {-| Generate a random mouse position given a screen width and a screen height
 -}

--- a/src/Random/Order.elm
+++ b/src/Random/Order.elm
@@ -1,0 +1,19 @@
+module Random.Order where
+{-| List of Order Generators
+
+# Generators
+@docs order
+-}
+
+import Random exposing (Generator)
+import Random.Extra exposing (selectWithDefault)
+
+{-| Generate a random order with equal probability.
+-}
+order : Generator Order
+order =
+  selectWithDefault EQ
+    [ LT
+    , EQ
+    , GT
+    ]

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -22,8 +22,8 @@ frequency errFrequency okFrequency errorGenerator okGenerator =
            | errFrequency == 0 -> 1
            | okFrequency  == 0 -> 0
            | otherwise ->
-              (toFloat okFrequency) /
-                (toFloat errFrequency + toFloat okFrequency)
+              (abs (toFloat okFrequency)) /
+                (abs (toFloat errFrequency) + abs (toFloat okFrequency))
   in
     customGenerator <|
       \seed ->

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -1,22 +1,45 @@
 module Random.Result where
+{-|
+
+# Generators
+@docs ok, error, result
+
+-}
 
 import Random       exposing (Generator, customGenerator, generate,float)
 import Random.Extra exposing (map, frequency)
 
 
+{-| Generate an ok result from a random generator of values
+-}
 ok : Generator value -> Generator (Result error value)
 ok generator =
   map Ok generator
 
 
+{-| Generate an error result from a random generator of errors
+-}
 error : Generator error -> Generator (Result error value)
 error generator =
   map Err generator
 
 
+{-| Generate an ok result or an error result with 50-50 chance
+
+This is simply implemented as follows:
+
+    result errorGenerator okGenerator =
+      frequency
+        [ (1, error errorGenerator)
+        , (1, ok okGenerator)
+        ] (ok okGenerator)
+
+If you want to generate results with a different frequency, tweak those
+numbers to your bidding in your own custom generators. 
+-}
 result : Generator error -> Generator value -> Generator (Result error value)
 result errorGenerator okGenerator =
   frequency
-    [ (1, map Err errorGenerator)
-    , (1, map Ok okGenerator)
-    ] (map Ok okGenerator)
+    [ (1, error errorGenerator)
+    , (1, ok okGenerator)
+    ] (ok okGenerator)

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -1,7 +1,7 @@
 module Random.Result where
 
-import Random exposing (Generator, customGenerator, generate,float)
-import Random.Extra exposing (map)
+import Random       exposing (Generator, customGenerator, generate,float)
+import Random.Extra exposing (map, frequency)
 
 
 ok : Generator value -> Generator (Result error value)
@@ -14,27 +14,9 @@ error generator =
   map Err generator
 
 
-frequency : Int -> Int -> Generator error -> Generator value -> Generator (Result error value)
-frequency errFrequency okFrequency errorGenerator okGenerator =
-  let
-      ratio =
-        if | errFrequency == 0 && okFrequency == 0 -> 0.5
-           | errFrequency == 0 -> 1
-           | okFrequency  == 0 -> 0
-           | otherwise ->
-              (abs (toFloat okFrequency)) /
-                (abs (toFloat errFrequency) + abs (toFloat okFrequency))
-  in
-    customGenerator <|
-      \seed ->
-        let (value, seed1) = generate (float 0 1) seed
-        in
-          if value < ratio
-            then
-              let (error, seed2) = generate errorGenerator seed1
-              in
-                (Err error, seed2)
-            else
-              let (ok, seed2) = generate okGenerator seed1
-              in
-                (Ok ok, seed2)
+result : Generator error -> Generator value -> Generator (Result error value)
+result errorGenerator okGenerator =
+  frequency
+    [ (1, map Err errorGenerator)
+    , (1, map Ok okGenerator)
+    ] (map Ok okGenerator)

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -1,0 +1,14 @@
+module Random.Result where
+
+import Random exposing (Generator)
+import Random.Extra exposing (map)
+
+
+result : Generator value -> Generator (Result error value)
+result generator =
+  map Ok generator
+
+
+error : Generator error -> Generator (Result error value)
+error generator =
+  map Err generator

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -1,5 +1,5 @@
 module Random.Result where
-{-|
+{-| List of Result Generators
 
 # Generators
 @docs ok, error, result
@@ -35,7 +35,7 @@ This is simply implemented as follows:
         ] (ok okGenerator)
 
 If you want to generate results with a different frequency, tweak those
-numbers to your bidding in your own custom generators. 
+numbers to your bidding in your own custom generators.
 -}
 result : Generator error -> Generator value -> Generator (Result error value)
 result errorGenerator okGenerator =

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -1,14 +1,40 @@
 module Random.Result where
 
-import Random exposing (Generator)
+import Random exposing (Generator, customGenerator, generate,float)
 import Random.Extra exposing (map)
 
 
-result : Generator value -> Generator (Result error value)
-result generator =
+ok : Generator value -> Generator (Result error value)
+ok generator =
   map Ok generator
 
 
 error : Generator error -> Generator (Result error value)
 error generator =
   map Err generator
+
+
+frequency : Int -> Int -> Generator error -> Generator value -> Generator (Result error value)
+frequency errFrequency okFrequency errorGenerator okGenerator =
+  let
+      ratio =
+        if | errFrequency == 0 && okFrequency == 0 -> 0.5
+           | errFrequency == 0 -> 1
+           | okFrequency  == 0 -> 0
+           | otherwise ->
+              (toFloat okFrequency) /
+                (toFloat errFrequency + toFloat okFrequency)
+  in
+    customGenerator <|
+      \seed ->
+        let (value, seed1) = generate (float 0 1) seed
+        in
+          if value < ratio
+            then
+              let (error, seed2) = generate errorGenerator seed1
+              in
+                (Err error, seed2)
+            else
+              let (ok, seed2) = generate okGenerator seed1
+              in
+                (Ok ok, seed2)

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -1,6 +1,12 @@
 module Random.Set where
 {-| List of Random Set Generators
 
+# Generators
+@docs empty, singleton, set, notInSet
+
+# Combinators
+@docs select, selectWithDefault
+
 -}
 
 import Set          exposing (Set)

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -4,7 +4,7 @@ module Random.Set where
 -}
 
 import Set          exposing (Set)
-import Random       exposing (Generator)
+import Random       exposing (Generator, list)
 import Random.Extra exposing (constant, map, dropIf, keepIf)
 
 
@@ -34,5 +34,9 @@ inSet : Set comparable -> Generator comparable -> Generator comparable
 inSet set generator =
   keepIf (flip Set.member set) generator
 
---set : Int -> Generator comparable -> Generator (Set comparable)
---set maxLength generator =
+
+{-| Generate a set of size at most given maxLength from a generator.
+-}
+set : Int -> Generator comparable -> Generator (Set comparable)
+set maxLength generator =
+  map Set.fromList (list maxLength generator)

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -34,5 +34,5 @@ inSet : Set comparable -> Generator comparable -> Generator comparable
 inSet set generator =
   keepIf (flip Set.member set) generator
 
-set : Int -> Generator comparable -> Generator (Set comparable)
-set maxLength generator =
+--set : Int -> Generator comparable -> Generator (Set comparable)
+--set maxLength generator =

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -28,12 +28,21 @@ notInSet : Set comparable -> Generator comparable -> Generator comparable
 notInSet set generator =
   dropIf (flip Set.member set) generator
 
-{-| A generator that creates values from a given set.
--}
-inSet : Set comparable -> Generator comparable -> Generator comparable
-inSet set generator =
-  keepIf (flip Set.member set) generator
 
+
+{-| Generate values from a set.
+Analogous to `Random.Extra.select` but with sets
+-}
+select : Set comparable -> Generator (Maybe comparable)
+select set =
+  Random.Extra.select (Set.toList set)
+
+{-| Generate values from a set or a default value.
+Analogous to `Random.Extra.selectWithDefault` but with sets
+-}
+selectWithDefault : comparable -> Set comparable -> Generator comparable
+selectWithDefault default set =
+  Random.Extra.selectWithDefault default (Set.toList set)
 
 {-| Generate a set of size at most given maxLength from a generator.
 -}

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -1,0 +1,38 @@
+module Random.Set where
+{-| List of Random Set Generators
+
+-}
+
+import Set          exposing (Set)
+import Random       exposing (Generator)
+import Random.Extra exposing (constant, map, dropIf, keepIf)
+
+
+{-| Generator that always returns the empty set
+-}
+empty : Generator (Set comparable)
+empty =
+  constant Set.empty
+
+
+{-| Generator that creates a singleton set from a generator
+-}
+singleton : Generator comparable -> Generator (Set comparable)
+singleton generator =
+  map Set.singleton generator
+
+
+{-| A generator that creates values not present in a given set.
+-}
+notInSet : Set comparable -> Generator comparable -> Generator comparable
+notInSet set generator =
+  dropIf (flip Set.member set) generator
+
+{-| A generator that creates values from a given set.
+-}
+inSet : Set comparable -> Generator comparable -> Generator comparable
+inSet set generator =
+  keepIf (flip Set.member set) generator
+
+set : Int -> Generator comparable -> Generator (Set comparable)
+set maxLength generator =

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -68,7 +68,7 @@ generateEvery time generator =
 {-| Generate a signal from a random generator that updates 60 times per second.
 -}
 generate : Generator a -> Signal a
-generate generator =
+generate =
   generateEvery (1000 / 60)
 
 

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -84,6 +84,10 @@ Here, the Elm Architecture is interpreted as follows:
       Signal.map view
         (Signal.foldp update initialModel actions)
 
+
+To use:
+    application initialModel actionGenerator update view
+
 -}
 application : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Signal view
 application initialModel actionGenerator update view =

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -9,6 +9,9 @@ module Random.Signal where
 
 # Generate Signals
 @docs generate, generateEvery
+
+# Generate a run of an application
+@docs application
 -}
 
 import Signal       exposing (Signal)
@@ -67,3 +70,22 @@ generateEvery time generator =
 generate : Generator a -> Signal a
 generate generator =
   generateEvery (1000 / 60)
+
+
+{-| Generate a random run of an application that follows the Elm Architecture.
+Here, the Elm Architecture is interpreted as follows:
+
+    initialModel : model
+    actions : Signal action
+    update : action -> model -> model
+    view : model -> view -- where view is usually Element or Html
+
+    main =
+      Signal.map view
+        (Signal.foldp update initialModel actions)
+
+-}
+application : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Signal view
+application initialModel actionGenerator update view =
+  Signal.map view
+    (Signal.foldp update initialModel (generate actionGenerator))

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -1,0 +1,69 @@
+module Random.Signal where
+{-| List of Signal Generators
+
+# Generators
+@docs constant
+
+# Random Seeds
+@docs randomSeed
+
+# Generate Signals
+@docs generate, generateEvery
+-}
+
+import Signal       exposing (Signal)
+import Random       exposing (Generator, Seed)
+import Random.Extra exposing (map)
+import Time         exposing (Time)
+
+{-| Generates constant signals.
+-}
+constant : Generator a -> Generator (Signal a)
+constant generator =
+  map Signal.constant generator
+
+
+{-| Generate a random seed that updates 60 times per second.
+Note: The seed uses the current Unix time.
+-}
+randomSeed : Signal Seed
+randomSeed =
+  randomSeedEvery (1000 / 60)
+
+{-| Generate a random seed that updates every given timestep.
+-}
+randomSeedEvery : Time -> Signal Seed
+randomSeedEvery timestep =
+  let
+      currentTime = Time.every timestep
+  in
+      Signal.map (floor >> Random.initialSeed) currentTime
+
+
+{-| Generate a signal from a random generator that updates every
+given number of milliseconds.
+-}
+generateEvery : Time -> Generator a -> Signal a
+generateEvery time generator =
+  let
+      initialModel =
+        { seed = Random.initialSeed 1
+        , generator = generator
+        }
+
+      update seed model =
+        { model | seed <- seed }
+
+      view model =
+        fst <| Random.generate model.generator model.seed
+
+  in
+      Signal.map view
+        (Signal.foldp update initialModel (randomSeedEvery time))
+
+
+{-| Generate a signal from a random generator that updates 60 times per second.
+-}
+generate : Generator a -> Signal a
+generate generator =
+  generateEvery (1000 / 60)

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -16,7 +16,7 @@ module Random.Signal where
 
 import Signal       exposing (Signal)
 import Random       exposing (Generator, Seed)
-import Random.Extra exposing (map)
+import Random.Extra exposing (map, reduce)
 import Time         exposing (Time)
 
 {-| Generates constant signals.
@@ -85,11 +85,30 @@ Here, the Elm Architecture is interpreted as follows:
         (Signal.foldp update initialModel actions)
 
 
-To use:
-    application initialModel actionGenerator update view
+How to use:
+
+    applicationGenerator =
+      application initialModel actionGenerator update view
+
+    main =
+      generate applicationGenerator
 
 -}
-application : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Signal view
+application : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Generator view
 application initialModel actionGenerator update view =
+  map view
+    (reduce update initialModel actionGenerator)
+
+{-| Create a running signal from an application that follows the Elm Architecture.
+This is analogous to `application` and works better as it avoids issues with
+`Random.Extra.reduce`.
+
+How to use:
+
+    main =
+      run initialModel actionGenerator update view
+-}
+run : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Signal view
+run initialModel actionGenerator update view =
   Signal.map view
     (Signal.foldp update initialModel (generate actionGenerator))

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -11,7 +11,7 @@ module Random.Signal where
 @docs generate, generateEvery
 
 # Generate a run of an application
-@docs application
+@docs application, run
 -}
 
 import Signal       exposing (Signal)

--- a/src/Random/String.elm
+++ b/src/Random/String.elm
@@ -5,12 +5,12 @@ module Random.String where
 @docs string, word, englishWord, capitalizedEnglishWord
 
 # Random Length String Generators
-@docs rangeLengthString, anyString, rangeLengthWord, rangeLengthEnglishWord, anyEnglishWord
+@docs rangeLengthString, rangeLengthWord, rangeLengthEnglishWord, anyEnglishWord
 
 -}
 
 import String exposing (fromList)
-import Random exposing (Generator, list, int, maxInt)
+import Random exposing (Generator, list, int)
 import Random.Char exposing (upperCaseLatin, lowerCaseLatin, unicode)
 import Random.Extra exposing (map, map2, flatMap)
 
@@ -32,16 +32,6 @@ and maximum length and a given character generator.
 rangeLengthString : Int -> Int -> Generator Char -> Generator String
 rangeLengthString minLength maxLength charGenerator =
   flatMap (\len -> string len charGenerator) (int minLength maxLength)
-
-
-{-| Generates a random string of random length between 0 and `maxInt`.
-Note: Will more often than note produce gigantic strings. Use for testing functions
-on strings. Not appropriate for testing layout. Please use the appropriate generators
-from the list such as `string`, `word`, `rangeLengthString`, or `rangeLengthWord`.
--}
-anyString : Generator String
-anyString =
-  rangeLengthString 0 maxInt unicode
 
 
 

--- a/src/Random/String.elm
+++ b/src/Random/String.elm
@@ -10,7 +10,7 @@ module Random.String where
 -}
 
 import String exposing (fromList)
-import Random exposing (..)
+import Random exposing (Generator, list, int, maxInt)
 import Random.Char exposing (upperCaseLatin, lowerCaseLatin, unicode)
 import Random.Extra exposing (map, map2, flatMap)
 

--- a/src/Random/String.elm
+++ b/src/Random/String.elm
@@ -9,10 +9,10 @@ module Random.String where
 
 -}
 
-import String (fromList)
-import Random (..)
-import Random.Char (upperCaseLatin, lowerCaseLatin, unicode)
-import Random.Extra (map, map2, flatMap)
+import String exposing (fromList)
+import Random exposing (..)
+import Random.Char exposing (upperCaseLatin, lowerCaseLatin, unicode)
+import Random.Extra exposing (map, map2, flatMap)
 
 
 
@@ -109,7 +109,7 @@ given a minimum length and a maximum length.
 -}
 rangeLengthCapitalizedEnglishWord : Int -> Int -> Generator String
 rangeLengthCapitalizedEnglishWord minLength maxLength =
-  flatMap capitalizedEnglishWord (int minLength maxLength) 
+  flatMap capitalizedEnglishWord (int minLength maxLength)
 
 
 

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -25,7 +25,7 @@ rangeLengthTimeout minTime maxTime =
   flatMap timeout (float minTime maxTime)
 
 
-threadedTask : Generator (Task error value) -> Generator (Task y ThreadID)
+threadedTask : Generator (Task x value) -> Generator (Task y ThreadID)
 threadedTask generator =
   map spawn generator
 
@@ -38,3 +38,7 @@ sequence generator =
 parallel : Generator (List (Task error value)) -> Generator (Task error (List ThreadID))
 parallel generator =
   map Task.parallel generator
+
+optional : Generator (List (Task x value)) -> Generator (Task y (List value))
+optional generator =
+  map Task.optional generator

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -22,47 +22,70 @@ import Random.Extra exposing (map, constant, flatMap)
 import Time         exposing (Time)
 import Signal       exposing (Address)
 
+{-| Generate a successful task from a generator of successful values
+-}
 task : Generator value -> Generator (Task error value)
 task generator =
   map succeed generator
 
+{-| Generate a failed task from a generator of error values
+-}
 error : Generator error -> Generator (Task error value)
 error generator =
   map fail generator
 
-
+{-| Generate a timeout of given time
+-}
 timeout : Time -> Generator (Task error ())
 timeout time =
   constant (sleep time)
 
-
+{-| Generate a timeout which times out at some point between a given minimum
+and maximum time
+-}
 rangeLengthTimeout : Time -> Time -> Generator (Task error ())
 rangeLengthTimeout minTime maxTime =
   flatMap timeout (float minTime maxTime)
 
 
+{-| Generate a task that is spawned in some independent thread given a
+task generator
+-}
 threadedTask : Generator (Task x value) -> Generator (Task y ThreadID)
 threadedTask generator =
   map spawn generator
 
 
+{-| Generate a sequence of tasks that are run in series from a list of tasks
+-}
 sequence : Generator (List (Task error value)) -> Generator (Task error (List value))
 sequence generator =
   map Task.sequence generator
 
 
+{-| Generate a sequence of tasks that are run in parallel from a list of tasks
+-}
 parallel : Generator (List (Task error value)) -> Generator (Task error (List ThreadID))
 parallel generator =
   map Task.parallel generator
 
+{-| Generate a sequence of optional tasks that are run in sequence from a list
+of tasks
+-}
 optional : Generator (List (Task x value)) -> Generator (Task y (List value))
 optional generator =
   map Task.optional generator
 
+{-| Generate a task that sends randomly generated values to a given address
+using a given random generator
+-}
 send : Address a -> Generator a -> Generator (Task error ())
 send address generator =
   map (Signal.send address) generator
 
+{-| Generate a task that broadcasts randomly generated values to a given address
+using a given random generator
+-}
 broadcast : List (Address a) -> Generator a -> Generator (Task error ())
 broadcast addresses generator =
   map (Task.broadcast addresses) generator

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -1,4 +1,19 @@
 module Random.Task where
+{-|
+
+# Generators
+@docs task, error, threadedTask
+
+# Timeout Generators
+@docs timeout, rangeLengthTimeout
+
+# Chaining Task Generators
+@docs sequence, parallel, optional
+
+# Generators that communicate with mailboxes
+@docs send, broadcast
+
+-}
 
 import Task         exposing (Task, ThreadID, spawn, succeed, fail, sleep)
 import Task.Extra   as Task

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -1,5 +1,5 @@
 module Random.Task where
-{-|
+{-| List of Task Generators
 
 # Generators
 @docs task, error, threadedTask

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -1,6 +1,6 @@
 module Random.Task where
 
-import Task         exposing (Task, succeed, fail, sleep)
+import Task         exposing (Task, ThreadID, spawn, succeed, fail, sleep)
 import Random       exposing (Generator, float)
 import Random.Extra exposing (map, constant, flatMap)
 import Time         exposing (Time)
@@ -22,3 +22,13 @@ timeout time =
 rangeLengthTimeout : Time -> Time -> Generator (Task error ())
 rangeLengthTimeout minTime maxTime =
   flatMap timeout (float minTime maxTime)
+
+
+threadedTask : Generator (Task error value) -> Generator (Task y ThreadID)
+threadedTask generator =
+  map spawn generator
+
+
+sequence : Generator (List (Task error value)) -> Generator (Task error (List value))
+sequence generator =
+  map Task.sequence generator

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -1,6 +1,7 @@
 module Random.Task where
 
 import Task         exposing (Task, ThreadID, spawn, succeed, fail, sleep)
+import Task.Extra   as Task
 import Random       exposing (Generator, float)
 import Random.Extra exposing (map, constant, flatMap)
 import Time         exposing (Time)
@@ -32,3 +33,8 @@ threadedTask generator =
 sequence : Generator (List (Task error value)) -> Generator (Task error (List value))
 sequence generator =
   map Task.sequence generator
+
+
+parallel : Generator (List (Task error value)) -> Generator (Task error (List ThreadID))
+parallel generator =
+  map Task.parallel generator

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -2,7 +2,7 @@ module Random.Task where
 {-| List of Task Generators
 
 # Generators
-@docs task, error, threadedTask
+@docs task, error, spawn
 
 # Timeout Generators
 @docs timeout, rangeLengthTimeout
@@ -15,7 +15,7 @@ module Random.Task where
 
 -}
 
-import Task         exposing (Task, ThreadID, spawn, succeed, fail, sleep)
+import Task         exposing (Task, ThreadID, succeed, fail, sleep)
 import Task.Extra   as Task
 import Random       exposing (Generator, float)
 import Random.Extra exposing (map, constant, flatMap)
@@ -51,9 +51,9 @@ rangeLengthTimeout minTime maxTime =
 {-| Generate a task that is spawned in some independent thread given a
 task generator
 -}
-threadedTask : Generator (Task x value) -> Generator (Task y ThreadID)
-threadedTask generator =
-  map spawn generator
+spawn : Generator (Task x value) -> Generator (Task y ThreadID)
+spawn generator =
+  map Task.spawn generator
 
 
 {-| Generate a sequence of tasks that are run in series from a list of tasks

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -5,6 +5,7 @@ import Task.Extra   as Task
 import Random       exposing (Generator, float)
 import Random.Extra exposing (map, constant, flatMap)
 import Time         exposing (Time)
+import Signal       exposing (Address)
 
 task : Generator value -> Generator (Task error value)
 task generator =
@@ -42,3 +43,11 @@ parallel generator =
 optional : Generator (List (Task x value)) -> Generator (Task y (List value))
 optional generator =
   map Task.optional generator
+
+send : Address a -> Generator a -> Generator (Task error ())
+send address generator =
+  map (Signal.send address) generator
+
+broadcast : List (Address a) -> Generator a -> Generator (Task error ())
+broadcast addresses generator =
+  map (Task.broadcast addresses) generator

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -1,0 +1,24 @@
+module Random.Task where
+
+import Task         exposing (Task, succeed, fail, sleep)
+import Random       exposing (Generator, float)
+import Random.Extra exposing (map, constant, flatMap)
+import Time         exposing (Time)
+
+task : Generator value -> Generator (Task error value)
+task generator =
+  map succeed generator
+
+error : Generator error -> Generator (Task error value)
+error generator =
+  map fail generator
+
+
+timeout : Time -> Generator (Task error ())
+timeout time =
+  constant (sleep time)
+
+
+rangeLengthTimeout : Time -> Time -> Generator (Task error ())
+rangeLengthTimeout minTime maxTime =
+  flatMap timeout (float minTime maxTime)

--- a/src/Random/Touch.elm
+++ b/src/Random/Touch.elm
@@ -6,8 +6,8 @@ module Random.Touch where
 
 -}
 
-import Touch exposing (Touch)
-import Random exposing (..)
+import Touch        exposing (Touch)
+import Random       exposing (Generator, int)
 import Random.Extra exposing (map2, map6, anyInt, positiveFloat)
 
 {-| Generate a random tap given a screen width and screen height

--- a/src/Random/Touch.elm
+++ b/src/Random/Touch.elm
@@ -8,8 +8,9 @@ module Random.Touch where
 
 import Touch        exposing (Touch)
 import Random       exposing (Generator, int)
-import Random.Extra exposing (map2, map6, positiveFloat)
+import Random.Extra exposing (map2, map6)
 import Random.Int   exposing (anyInt)
+import Random.Float exposing (positiveFloat)
 
 {-| Generate a random tap given a screen width and screen height
 -}

--- a/src/Random/Touch.elm
+++ b/src/Random/Touch.elm
@@ -6,9 +6,9 @@ module Random.Touch where
 
 -}
 
-import Touch (Touch)
-import Random (..)
-import Random.Extra (map2, map6, anyInt, positiveFloat)
+import Touch exposing (Touch)
+import Random exposing (..)
+import Random.Extra exposing (map2, map6, anyInt, positiveFloat)
 
 {-| Generate a random tap given a screen width and screen height
 -}

--- a/src/Random/Touch.elm
+++ b/src/Random/Touch.elm
@@ -8,7 +8,8 @@ module Random.Touch where
 
 import Touch        exposing (Touch)
 import Random       exposing (Generator, int)
-import Random.Extra exposing (map2, map6, anyInt, positiveFloat)
+import Random.Extra exposing (map2, map6, positiveFloat)
+import Random.Int   exposing (anyInt)
 
 {-| Generate a random tap given a screen width and screen height
 -}

--- a/src/Random/Window.elm
+++ b/src/Random/Window.elm
@@ -6,8 +6,8 @@ module Random.Window where
 
 -}
 
-import Random (..)
-import Random.Extra (zip)
+import Random exposing (..)
+import Random.Extra exposing (zip)
 
 {-| Generate a random tuple of window dimensions given a minimum screen width, a maximum screen width, a minimum screen height, a maximum screen height
 -}

--- a/src/Random/Window.elm
+++ b/src/Random/Window.elm
@@ -6,7 +6,7 @@ module Random.Window where
 
 -}
 
-import Random exposing (..)
+import Random       exposing (Generator, int)
 import Random.Extra exposing (zip)
 
 {-| Generate a random tuple of window dimensions given a minimum screen width, a maximum screen width, a minimum screen height, a maximum screen height

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -1,0 +1,12 @@
+module Utils where
+
+import List exposing (drop)
+
+get : Int -> List a -> Maybe a
+get index list =
+  if index < 0
+  then Nothing
+  else
+    case List.drop index list of
+      [] -> Nothing
+      x :: xs -> Just x


### PR DESCRIPTION
Update to Elm 0.15. 

This update contains lots of clean-up. Certain broken functions were removed. Many functions were streamlined and re-implemented in terms of other functions. A few functions were added. But most importantly, `Random.Extra` exports way fewer functions and these functions have been extracted into different modules. New modules have also been introduced to deal with asynchronous programming in Elm 0.15. 

Most notably, `Random.Task` and `Random.Signal` have been added. These allow you to mock tasks, signals, and even entire applications. 
### Modules added :
- `Random.Int` : contains extra Int generators (previously in `Random.Extra`)
- `Random.Float` : contains extra Float generators (previously in `Random.Extra`)
- `Random.Function`: contains extra Function generators (previously in `Random.Extra`)
- `Random.List` : contains extra List generators (previously in `Random.Extra`)
- `Random.Mailbox` : contains Mailbox and Address generators
- `Random.Maybe` : contains Maybe generators
- `Random.Order` : contains Order generators
- `Random.Result` : contains Result generators
- `Random.Signal` : contains Signal generators and other useful functions
- `Random.Set` : contains Set generators
- `Random.Task` : contains Task generators
### Notable additions :

**Random.Extra**
- `frequency : List (Float, Generator a) -> Generator a -> Generator a`
- `keepIf : (a -> Bool) -> Generator a -> Generator a`
- `dropIf : (a -> Bool) -> Generator a -> Generator a`
- `flattenList : List (Generator a) -> Generator (List a)`
- `andMap : Generator (a -> b) -> Generator a -> Generator b`
- `generateN : Int -> Generator a -> Seed -> List a`
- `reduce : (a -> b -> b) -> b -> Generator a -> Generator b` 

**Random.Float**
- `unitRange : Generator Float`
- `normal : Float -> Float -> Float -> Generator Float`
- `standardNormal : Generator Float`
- `gaussian : Generator Float`

**Random.Mailbox**
- `mailbox : Generator a -> Generator (Mailbox a)`
- `address : Generator a -> Generator (Address a)`

**Random.Maybe**
- `maybe : Generator a -> Generator (Maybe a)`

**Random.Order**
- `order : Generator Order`

**Random.Result**
- `ok : Generator value -> Generator (Result error value)`
- `error : Generator error -> Generator (Result error value)`
- `result : Generator error -> Generator value -> Generator (Result error value)`

**Random.Set**
- `empty : Generator (Set comparable)`
- `singleton : Generator comparable -> Generator (Set comparable)`
- `notInSet : Set comparable -> Generator comparable -> Generator comparable`
- `select : Set comparable -> Generator (Maybe comparable)`
- `selectWithDefault : comparable -> Set comparable -> Generator comparable`
- `set : Int -> Generator comparable -> Generator (Set comparable)`

**Random.Signal**
- `constant : Generator a -> Generator (Signal a)` 
- `randomSeed : Signal Seed`
- `randomSeedEvery : Time -> Signal Seed`
- `generateEvery : Time -> Generator a -> Signal a`
- `generate : Generator a -> Signal a`
- `application : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Generator view`
- `run : model -> Generator action -> (action -> model -> model) -> (model -> view) -> Signal view`

**Random.Task**
- `task : Generator value -> Generator (Task error value)`
- `error : Generator error -> Generator (Task error value)`
- `timeout : Time -> Generator (Task error ())`
- `rangeLengthTimeout : Time -> Time -> Generator (Task error ())`
- `spawn : Generator (Task x value) -> Generator (Task y ThreadID)`
- `sequence : Generator (List (Task error value)) -> Generator (Task error (List value))`
- `parallel : Generator (List (Task error value)) -> Generator (Task error (List ThreadID))`
- `optional : Generator (List (Task error value)) -> Generator (Task error (List value))`
- `send :  Address a -> Generator a -> Generator (Task error ())`
- `broadcast : List (Address a) -> Generator a -> Generator (Task error ())`
### Notable removed from previous version :
- `anyString : Generator String`. This generator was profoundly broken as it could potentially generate a string of length maxInt, which completely trashed the stack. Now there is not simple string generator anymore and therefore the user must specify the length of the expected strings to be generated. 
